### PR TITLE
Fix IDE warnings and modernize codebase

### DIFF
--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -68,7 +68,7 @@ type S3CError struct {
 	Category   ErrorCategory `json:"category"`
 	Severity   Severity      `json:"severity"`
 	Message    string        `json:"message"`
-	Details    interface{}   `json:"details,omitempty"`
+	Details    any           `json:"details,omitempty"`
 	Suggestion string        `json:"suggestion,omitempty"`
 	Wrapped    error         `json:"-"` // Original error, not serialized
 }
@@ -106,7 +106,7 @@ func NewS3CError(code ErrorCode, category ErrorCategory, severity Severity, mess
 }
 
 // WithDetails adds details to the error
-func (e *S3CError) WithDetails(details interface{}) *S3CError {
+func (e *S3CError) WithDetails(details any) *S3CError {
 	e.Details = details
 	return e
 }
@@ -128,9 +128,9 @@ func NewValidationError(code ErrorCode, message string) *S3CError {
 	return NewS3CError(code, CategoryValidation, SeverityError, message)
 }
 
-func NewInvalidInputError(field string, value interface{}) *S3CError {
+func NewInvalidInputError(field string, value any) *S3CError {
 	return NewValidationError(CodeInvalidInput, fmt.Sprintf("Invalid input for field '%s'", field)).
-		WithDetails(map[string]interface{}{
+		WithDetails(map[string]any{
 			"field": field,
 			"value": value,
 		}).
@@ -139,7 +139,7 @@ func NewInvalidInputError(field string, value interface{}) *S3CError {
 
 func NewMissingFieldError(field string) *S3CError {
 	return NewValidationError(CodeMissingField, fmt.Sprintf("Required field '%s' is missing", field)).
-		WithDetails(map[string]interface{}{
+		WithDetails(map[string]any{
 			"field": field,
 		}).
 		WithSuggestion(fmt.Sprintf("Please provide a value for '%s'", field))
@@ -158,7 +158,7 @@ func NewS3ConnectionError(err error) *S3CError {
 
 func NewS3BucketNotFoundError(bucket string) *S3CError {
 	return NewS3Error(CodeS3BucketNotFound, fmt.Sprintf("Bucket '%s' not found", bucket)).
-		WithDetails(map[string]interface{}{
+		WithDetails(map[string]any{
 			"bucket": bucket,
 		}).
 		WithSuggestion("Verify the bucket name and your access permissions")
@@ -166,7 +166,7 @@ func NewS3BucketNotFoundError(bucket string) *S3CError {
 
 func NewS3ObjectNotFoundError(bucket, key string) *S3CError {
 	return NewS3Error(CodeS3ObjectNotFound, fmt.Sprintf("Object '%s' not found in bucket '%s'", key, bucket)).
-		WithDetails(map[string]interface{}{
+		WithDetails(map[string]any{
 			"bucket": bucket,
 			"key":    key,
 		}).
@@ -175,7 +175,7 @@ func NewS3ObjectNotFoundError(bucket, key string) *S3CError {
 
 func NewS3AccessDeniedError(operation, resource string) *S3CError {
 	return NewS3Error(CodeS3AccessDenied, fmt.Sprintf("Access denied for %s on %s", operation, resource)).
-		WithDetails(map[string]interface{}{
+		WithDetails(map[string]any{
 			"operation": operation,
 			"resource":  resource,
 		}).
@@ -185,7 +185,7 @@ func NewS3AccessDeniedError(operation, resource string) *S3CError {
 func NewS3OperationError(operation string, err error) *S3CError {
 	return NewS3Error(CodeS3Operation, fmt.Sprintf("S3 %s operation failed", operation)).
 		WithWrapped(err).
-		WithDetails(map[string]interface{}{
+		WithDetails(map[string]any{
 			"operation": operation,
 		})
 }
@@ -197,7 +197,7 @@ func NewConfigError(code ErrorCode, message string) *S3CError {
 
 func NewProfileNotFoundError(profile string) *S3CError {
 	return NewConfigError(CodeProfileNotFound, fmt.Sprintf("AWS profile '%s' not found", profile)).
-		WithDetails(map[string]interface{}{
+		WithDetails(map[string]any{
 			"profile": profile,
 		}).
 		WithSuggestion("Check your ~/.aws/credentials file or AWS profile configuration")
@@ -216,7 +216,7 @@ func NewNetworkError(code ErrorCode, message string) *S3CError {
 
 func NewNetworkTimeoutError(operation string) *S3CError {
 	return NewNetworkError(CodeNetworkTimeout, fmt.Sprintf("Network timeout during %s", operation)).
-		WithDetails(map[string]interface{}{
+		WithDetails(map[string]any{
 			"operation": operation,
 		}).
 		WithSuggestion("Check your network connection and try again")
@@ -230,7 +230,7 @@ func NewInternalError(code ErrorCode, message string) *S3CError {
 func NewFileOperationError(operation, path string, err error) *S3CError {
 	return NewInternalError(CodeFileOperation, fmt.Sprintf("File %s failed for %s", operation, path)).
 		WithWrapped(err).
-		WithDetails(map[string]interface{}{
+		WithDetails(map[string]any{
 			"operation": operation,
 			"path":      path,
 		})
@@ -239,7 +239,7 @@ func NewFileOperationError(operation, path string, err error) *S3CError {
 func NewNotImplementedError(feature string) *S3CError {
 	return NewInternalError(CodeNotImplemented, fmt.Sprintf("Feature '%s' is not implemented", feature)).
 		WithWrapped(errors.ErrUnsupported). // Go 1.21+ sentinel error
-		WithDetails(map[string]interface{}{
+		WithDetails(map[string]any{
 			"feature": feature,
 		}).
 		WithSuggestion("This feature is planned for a future release")

--- a/pkg/handler/api_handler.go
+++ b/pkg/handler/api_handler.go
@@ -33,10 +33,10 @@ type S3ServiceCreator func(ctx context.Context, cfg service.S3Config) (service.S
 
 // APIResponse represents a standard API response
 type APIResponse struct {
-	Success   bool        `json:"success"`
-	Data      interface{} `json:"data,omitempty"`
-	Error     string      `json:"error,omitempty"`
-	RequestID string      `json:"requestId,omitempty"`
+	Success   bool   `json:"success"`
+	Data      any    `json:"data,omitempty"`
+	Error     string `json:"error,omitempty"`
+	RequestID string `json:"requestId,omitempty"`
 }
 
 // APIErrorResponse represents a structured error response
@@ -48,13 +48,13 @@ type APIErrorResponse struct {
 
 // APIError represents detailed error information
 type APIError struct {
-	Code       string      `json:"code"`
-	Message    string      `json:"message"`
-	Details    interface{} `json:"details,omitempty"`
-	Suggestion string      `json:"suggestion,omitempty"`
-	Category   string      `json:"category,omitempty"`
-	Severity   string      `json:"severity,omitempty"`
-	Retryable  bool        `json:"retryable,omitempty"`
+	Code       string `json:"code"`
+	Message    string `json:"message"`
+	Details    any    `json:"details,omitempty"`
+	Suggestion string `json:"suggestion,omitempty"`
+	Category   string `json:"category,omitempty"`
+	Severity   string `json:"severity,omitempty"`
+	Retryable  bool   `json:"retryable,omitempty"`
 }
 
 // APIHandler handles API requests with dependency injection
@@ -111,7 +111,7 @@ func (h *APIHandler) HandleProfiles(w http.ResponseWriter, r *http.Request) {
 
 	response := APIResponse{
 		Success:   true,
-		Data:      map[string]interface{}{"profiles": profiles},
+		Data:      map[string]any{"profiles": profiles},
 		RequestID: requestID,
 	}
 
@@ -184,7 +184,7 @@ func (h *APIHandler) HandleSettings(w http.ResponseWriter, r *http.Request) {
 
 	response := APIResponse{
 		Success:   true,
-		Data:      map[string]interface{}{"message": "S3 connection configured successfully"},
+		Data:      map[string]any{"message": "S3 connection configured successfully"},
 		RequestID: requestID,
 	}
 
@@ -220,7 +220,7 @@ func (h *APIHandler) HandleBuckets(w http.ResponseWriter, r *http.Request) {
 
 	response := APIResponse{
 		Success:   true,
-		Data:      map[string]interface{}{"buckets": buckets},
+		Data:      map[string]any{"buckets": buckets},
 		RequestID: requestID,
 	}
 
@@ -282,7 +282,7 @@ func (h *APIHandler) HandleBucketCreate(w http.ResponseWriter, r *http.Request) 
 
 	response := APIResponse{
 		Success: true,
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"message": "Bucket created successfully",
 			"bucket":  req.Name,
 		},
@@ -301,7 +301,7 @@ func (h *APIHandler) HandleShutdown(w http.ResponseWriter, r *http.Request) {
 
 	response := APIResponse{
 		Success:   true,
-		Data:      map[string]interface{}{"message": "Server shutting down"},
+		Data:      map[string]any{"message": "Server shutting down"},
 		RequestID: requestID,
 	}
 
@@ -384,7 +384,7 @@ func (h *APIHandler) HandleFolderCreate(w http.ResponseWriter, r *http.Request) 
 
 	response := APIResponse{
 		Success: true,
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"message": "Folder created successfully",
 			"bucket":  req.Bucket,
 			"prefix":  req.Prefix,
@@ -574,7 +574,7 @@ func (h *APIHandler) HandleObjectsDelete(w http.ResponseWriter, r *http.Request)
 
 	response := APIResponse{
 		Success: true,
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"message":     "Objects deleted successfully",
 			"bucket":      req.Bucket,
 			"deletedKeys": req.Keys,
@@ -636,7 +636,7 @@ func (h *APIHandler) HandleObjectsUpload(w http.ResponseWriter, r *http.Request)
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	var results []map[string]interface{}
+	var results []map[string]any
 	var errors []string
 
 	// Process each file upload
@@ -684,7 +684,7 @@ func (h *APIHandler) HandleObjectsUpload(w http.ResponseWriter, r *http.Request)
 		}
 
 		// Add successful result
-		results = append(results, map[string]interface{}{
+		results = append(results, map[string]any{
 			"key":      output.Key,
 			"etag":     output.ETag,
 			"size":     len(fileContent),
@@ -693,7 +693,7 @@ func (h *APIHandler) HandleObjectsUpload(w http.ResponseWriter, r *http.Request)
 	}
 
 	// Prepare response
-	responseData := map[string]interface{}{
+	responseData := map[string]any{
 		"bucket":   bucket,
 		"uploaded": results,
 		"success":  len(results),
@@ -767,7 +767,7 @@ func (h *APIHandler) HandleObjectsDownload(w http.ResponseWriter, r *http.Reques
 		if len(req.Keys) == 1 {
 			h.downloadSingleFile(w, ctx, req.Bucket, req.Keys[0], requestID)
 		} else {
-			h.downloadMultipleFiles(w, ctx, req.Bucket, req.Keys, requestID)
+			h.downloadMultipleFiles(w, ctx, req.Bucket, req.Keys)
 		}
 	case "folder":
 		if req.Prefix == "" {
@@ -813,7 +813,7 @@ func (h *APIHandler) downloadSingleFile(w http.ResponseWriter, ctx context.Conte
 }
 
 // downloadMultipleFiles downloads multiple files as a ZIP
-func (h *APIHandler) downloadMultipleFiles(w http.ResponseWriter, ctx context.Context, bucket string, keys []string, requestID string) {
+func (h *APIHandler) downloadMultipleFiles(w http.ResponseWriter, ctx context.Context, bucket string, keys []string) {
 	// Set response headers for ZIP
 	w.Header().Set("Content-Type", "application/zip")
 	w.Header().Set("Content-Disposition", "attachment; filename=\"files.zip\"")
@@ -929,7 +929,7 @@ func (h *APIHandler) HandleHealth(w http.ResponseWriter, r *http.Request) {
 
 	response := APIResponse{
 		Success: true,
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"status": "ok",
 			"time":   time.Now().Format(time.RFC3339),
 		},
@@ -946,7 +946,7 @@ func (h *APIHandler) HandleStatus(w http.ResponseWriter, r *http.Request) {
 	if h.s3Service == nil {
 		response := APIResponse{
 			Success: true,
-			Data: map[string]interface{}{
+			Data: map[string]any{
 				"connected": false,
 				"message":   "Not connected",
 			},
@@ -964,7 +964,7 @@ func (h *APIHandler) HandleStatus(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		response := APIResponse{
 			Success: true,
-			Data: map[string]interface{}{
+			Data: map[string]any{
 				"connected": false,
 				"message":   "Connection failed",
 				"error":     err.Error(),
@@ -976,7 +976,7 @@ func (h *APIHandler) HandleStatus(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Return connection status with configuration details
-	responseData := map[string]interface{}{
+	responseData := map[string]any{
 		"connected": true,
 		"message":   "Connected to S3",
 	}
@@ -1005,18 +1005,6 @@ func (h *APIHandler) writeResponse(w http.ResponseWriter, response APIResponse) 
 	if err := json.NewEncoder(w).Encode(response); err != nil {
 		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
 	}
-}
-
-func (h *APIHandler) writeError(w http.ResponseWriter, message string, statusCode int) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(statusCode)
-
-	response := APIResponse{
-		Success: false,
-		Error:   message,
-	}
-
-	json.NewEncoder(w).Encode(response)
 }
 
 // writeStructuredError writes a structured error response based on s3c errors

--- a/pkg/handler/api_handler_test.go
+++ b/pkg/handler/api_handler_test.go
@@ -81,22 +81,13 @@ func (m *mockS3Service) CreateFolder(ctx context.Context, bucket, prefix string)
 	return nil
 }
 
-func mockS3ServiceCreator(mockService *mockS3Service) S3ServiceCreator {
-	return func(ctx context.Context, cfg service.S3Config) (service.S3Operations, error) {
-		if mockService.testConnectionErr != nil && mockService.testConnectionErr.Error() == "creation_error" {
-			return nil, mockService.testConnectionErr
-		}
-		return mockService, nil
-	}
-}
-
 // Integration tests using real ServeMux to test POST-unified API
 func TestAPIHandler_Integration(t *testing.T) {
 	tests := []struct {
 		name           string
 		method         string
 		url            string
-		body           interface{}
+		body           any
 		expectedStatus int
 		setupHandler   func(*APIHandler)
 	}{
@@ -104,7 +95,7 @@ func TestAPIHandler_Integration(t *testing.T) {
 			name:           "POST /api/profiles success",
 			method:         "POST",
 			url:            "/api/profiles",
-			body:           map[string]interface{}{},
+			body:           map[string]any{},
 			expectedStatus: http.StatusOK,
 			setupHandler: func(h *APIHandler) {
 				h.profileProvider = &mockProfileProvider{

--- a/pkg/service/s3_service.go
+++ b/pkg/service/s3_service.go
@@ -258,7 +258,7 @@ func (s *AWSS3Service) CreateBucket(ctx context.Context, bucketName string) erro
 	if err != nil {
 		s.logger.Error("Failed to create S3 bucket", "error", err, "bucketName", bucketName, "region", s.config.Region)
 		return convertS3Error("create bucket", err).(*s3cerrors.S3CError).
-			WithDetails(map[string]interface{}{
+			WithDetails(map[string]any{
 				"bucket": bucketName,
 				"region": s.config.Region,
 			})
@@ -327,7 +327,7 @@ func (s *AWSS3Service) ListObjects(ctx context.Context, input ListObjectsInput) 
 			"prefix", input.Prefix,
 		)
 		return nil, convertS3Error("list objects", err).(*s3cerrors.S3CError).
-			WithDetails(map[string]interface{}{
+			WithDetails(map[string]any{
 				"bucket": input.Bucket,
 				"prefix": input.Prefix,
 			})
@@ -425,7 +425,7 @@ func (s *AWSS3Service) DeleteObject(ctx context.Context, bucket, key string) err
 	})
 	if err != nil {
 		return convertS3Error("delete object", err).(*s3cerrors.S3CError).
-			WithDetails(map[string]interface{}{
+			WithDetails(map[string]any{
 				"bucket": bucket,
 				"key":    key,
 			})
@@ -458,7 +458,7 @@ func (s *AWSS3Service) DeleteObjects(ctx context.Context, bucket string, keys []
 	})
 	if err != nil {
 		return convertS3Error("delete objects", err).(*s3cerrors.S3CError).
-			WithDetails(map[string]interface{}{
+			WithDetails(map[string]any{
 				"bucket": bucket,
 				"keys":   keys,
 				"count":  len(keys),
@@ -489,7 +489,7 @@ func (s *AWSS3Service) UploadObject(ctx context.Context, input UploadObjectInput
 	result, err := s.client.PutObject(ctx, s3Input)
 	if err != nil {
 		return nil, convertS3Error("upload object", err).(*s3cerrors.S3CError).
-			WithDetails(map[string]interface{}{
+			WithDetails(map[string]any{
 				"bucket": input.Bucket,
 				"key":    input.Key,
 				"size":   len(input.Body),
@@ -515,7 +515,7 @@ func (s *AWSS3Service) DownloadObject(ctx context.Context, input DownloadObjectI
 	})
 	if err != nil {
 		return nil, convertS3Error("download object", err).(*s3cerrors.S3CError).
-			WithDetails(map[string]interface{}{
+			WithDetails(map[string]any{
 				"bucket": input.Bucket,
 				"key":    input.Key,
 			})
@@ -526,7 +526,7 @@ func (s *AWSS3Service) DownloadObject(ctx context.Context, input DownloadObjectI
 	body, err := io.ReadAll(result.Body)
 	if err != nil {
 		return nil, s3cerrors.NewFileOperationError("read", "S3 object body", err).
-			WithDetails(map[string]interface{}{
+			WithDetails(map[string]any{
 				"bucket": input.Bucket,
 				"key":    input.Key,
 			})


### PR DESCRIPTION
## Summary
- Replace `interface{}` with `any` across all Go files (Go 1.18+ modernization)
- Remove unused parameter `requestID` from `downloadMultipleFiles` function
- Remove unused `writeError` method from `APIHandler`
- Remove unused `mockS3ServiceCreator` function from tests

## Test plan
- [x] All unit tests pass
- [x] Integration tests pass
- [x] Code formatted with `go fmt`
- [x] No breaking changes to public API

## Details
This PR addresses IDE warnings and modernizes the codebase to use Go 1.18+ features:

### Interface{} → any modernization
- **pkg/handler/api_handler.go**: 17 occurrences updated
- **pkg/service/s3_service.go**: 7 occurrences updated  
- **pkg/errors/errors.go**: 13 occurrences updated
- **pkg/handler/api_handler_test.go**: 2 occurrences updated

### Dead code removal
- Removed unused `requestID` parameter from `downloadMultipleFiles`
- Removed unused `writeError` method
- Removed unused `mockS3ServiceCreator` test helper

All tests continue to pass, confirming no functionality was broken.